### PR TITLE
helm: adding deployment strategy

### DIFF
--- a/charts/nginx-echo-headers/Chart.yaml
+++ b/charts/nginx-echo-headers/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nginx-echo-headers/templates/deployment.yaml
+++ b/charts/nginx-echo-headers/templates/deployment.yaml
@@ -8,6 +8,16 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    {{- if and (ne .Values.deployment.strategy.type "Recreate") (ne .Values.deployment.strategy.type "RollingUpdate") }}
+    {{- fail "deployment.strategy.type is case-sensitive and must be one of 'Recreate' or 'RollingUpdate'" }}
+    {{- end }}
+    type: {{ .Values.deployment.strategy.type }}
+    {{- if ne .Values.deployment.strategy.type "Recreate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.deployment.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.deployment.strategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "nginx-echo-headers.selectorLabels" . | nindent 6 }}

--- a/charts/nginx-echo-headers/values.yaml
+++ b/charts/nginx-echo-headers/values.yaml
@@ -13,6 +13,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.0.2"
 
+deployment:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25
+      maxUnavailable: 25
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Deployment strategy being added - enforcing `type` to either RollingUpdate or Recreate (the only two allowable options)
`MaxSurge` and `MaxUnavailable` are both conditional on whether `strategy.type` if not `Recreate`